### PR TITLE
Use -M sphinx-build flag to split location of doctrees and html

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,11 +44,11 @@ jobs:
           environment:
             PIP_CONSTRAINT: ../napari/resources/constraints/constraints_py3.10_docs.txt
       - store_artifacts:
-          path: docs/docs/_build/
+          path: docs/docs/_build/html
       - persist_to_workspace:
           root: .
           paths:
-            - docs/docs/_build/
+            - docs/docs/_build/html
 workflows:
   build-docs:
     jobs:

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -74,7 +74,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: docs
-          path: docs/docs/_build
+          path: docs/docs/_build/html
 
   deploy:
     if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/heads/main'))
@@ -86,9 +86,6 @@ jobs:
         with:
           name: docs
           path: docs
-
-      - name: remove doctrees
-        run: rm -rf docs/.doctrees
 
       - name: get directory name
         # if this is a tag, use the tag name as the directory name else dev
@@ -104,7 +101,7 @@ jobs:
         with:
           deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
           external_repository: napari/napari.github.io
-          publish_dir: docs/docs/_build
+          publish_dir: docs/docs/_build/html
           publish_branch: gh-pages
           destination_dir: ${{ env.branch_name }}
           cname: napari.org

--- a/.github/workflows/circleci.yml
+++ b/.github/workflows/circleci.yml
@@ -19,6 +19,6 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           api-token: ${{ secrets.CIRCLECI_TOKEN }}
-          artifact-path: 0/docs/docs/_build/index.html
+          artifact-path: 0/docs/docs/_build/html/index.html
           circleci-jobs: build-docs
           job-title: Check the rendered docs here!

--- a/Makefile
+++ b/Makefile
@@ -27,10 +27,10 @@ prep-docs:
 	python $(docs_dir)/_scripts/prep_docs.py
 
 docs-build: prep-docs
-	NAPARI_CONFIG="" NAPARI_APPLICATION_IPY_INTERACTIVE=0 sphinx-build -b html docs/ docs/_build -D sphinx_gallery_conf.examples_dirs=$(GALLERY_PATH) $(SPHINXOPTS)
+	NAPARI_CONFIG="" NAPARI_APPLICATION_IPY_INTERACTIVE=0 sphinx-build -M html docs/ docs/_build -D sphinx_gallery_conf.examples_dirs=$(GALLERY_PATH) $(SPHINXOPTS)
 
 docs-xvfb: prep-docs
-	NAPARI_CONFIG="" NAPARI_APPLICATION_IPY_INTERACTIVE=0 xvfb-run --auto-servernum sphinx-build -b html docs/ docs/_build -D sphinx_gallery_conf.examples_dirs=$(GALLERY_PATH) $(SPHINXOPTS)
+	NAPARI_CONFIG="" NAPARI_APPLICATION_IPY_INTERACTIVE=0 xvfb-run --auto-servernum sphinx-build -M html docs/ docs/_build -D sphinx_gallery_conf.examples_dirs=$(GALLERY_PATH) $(SPHINXOPTS)
 
 docs: clean docs-install docs-build
 
@@ -55,7 +55,7 @@ html-live: prep-docs
 		$(SPHINXOPTS)
 
 html-noplot: clean prep-docs
-	NAPARI_APPLICATION_IPY_INTERACTIVE=0 sphinx-build -D plot_gallery=0 -b html docs/ docs/_build -D sphinx_gallery_conf.examples_dirs=$(GALLERY_PATH) $(SPHINXOPTS)
+	NAPARI_APPLICATION_IPY_INTERACTIVE=0 sphinx-build -D plot_gallery=0 -M html docs/ docs/_build -D sphinx_gallery_conf.examples_dirs=$(GALLERY_PATH) $(SPHINXOPTS)
 
 linkcheck-files:
 	NAPARI_APPLICATION_IPY_INTERACTIVE=0 sphinx-build -b linkcheck -D plot_gallery=0 --color docs/ docs/_build ${FILES} -D sphinx_gallery_conf.examples_dirs=$(GALLERY_PATH) $(SPHINXOPTS)


### PR DESCRIPTION
# References and relevant issues
Alternative to deleting doctrees from:
https://github.com/napari/docs/pull/348#issuecomment-1946519040

# Description
The recommend approach from sphinx is to use sphinx-build make-mode (`-M` option), which splits the output of doctrees and html:
https://www.sphinx-doc.org/en/master/man/sphinx-build.html#cmdoption-sphinx-build-M
```
Note
The default output directory locations when using make-mode differ from the defaults when using [-b](https://www.sphinx-doc.org/en/master/man/sphinx-build.html#cmdoption-sphinx-build-b).
doctrees are saved to <outputdir>/doctrees
output files are saved to <outputdir>/<builder name>
```

For `html` the output dir then becomes `html` and it's recommended to use that for upload to GitHub Pages:
https://www.sphinx-doc.org/en/master/tutorial/deploying.html#id5
